### PR TITLE
Hide github ribbon on small screens

### DIFF
--- a/css/ritmap.css
+++ b/css/ritmap.css
@@ -6,7 +6,6 @@ body {
     text-align:center;
 }
 
-
 @media only screen and (max-width: 600px) {
     .hide-on-small-screen {
         display: none;

--- a/css/ritmap.css
+++ b/css/ritmap.css
@@ -5,3 +5,10 @@ body {
 .center {
     text-align:center;
 }
+
+
+@media only screen and (max-width: 600px) {
+    .hide-on-small-screen {
+        display: none;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
             </ul>
         </div>
     </div>
-                <a href="https://github.com/ritmap/ritmap.github.io"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 100;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+                <a class="hide-on-small-screen" href="https://github.com/ritmap/ritmap.github.io"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 100;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 
                 <noscript><p>Javascript is required... Sorry :(</p></noscript>
                 <div class="center" id="map">

--- a/pokemongo.html
+++ b/pokemongo.html
@@ -37,7 +37,7 @@
             </ul>
         </div>
     </div>
-                <a href="https://github.com/ritmap/ritmap.github.io"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 100;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+                <a class="hide-on-small-screen" href="https://github.com/ritmap/ritmap.github.io"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 100;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 
                 <noscript><p>Javascript is required... Sorry :(</p></noscript>
                 <div class="center" id="map">


### PR DESCRIPTION
This hides the github ribbon in the top right when the screen size is small enough that it can start overlapping the header text.